### PR TITLE
Costco web scraping init 20240619

### DIFF
--- a/3. Costco/Costco_Wait_Times_US.csv
+++ b/3. Costco/Costco_Wait_Times_US.csv
@@ -1,0 +1,231 @@
+,city_name,city_avg_wait,store_location,location_wait
+0,"Orange County, CA",10,Cypress,10
+1,"Orange County, CA",10,Fountain Valley,1
+2,"Orange County, CA",10,Fullerton,5
+3,"Orange County, CA",10,Garden Grove,15
+4,"Orange County, CA",10,Huntington Beach,10
+5,"Orange County, CA",10,Irvine,10
+6,"Orange County, CA",10,La Habra,10
+7,"Orange County, CA",10,Laguna Marketplace,20
+8,"Orange County, CA",10,Laguna Niguel,10
+9,"Orange County, CA",10,San Juan Capistrano,10
+10,"Orange County, CA",10,Tustin,5
+11,"Orange County, CA",10,Tustin Ranch,15
+12,"Orange County, CA",10,Westminster Business Center,10
+13,"Orange County, CA",10,Yorba Linda,5
+14,Tampa Bay,13,Brandon,15
+15,Tampa Bay,13,W Tampa (Linebaugh Ave),10
+16,Tampa Bay,13,Clearwater,20
+17,Tampa Bay,13,Wesley Chapel,15
+18,Tampa Bay,13,Bradenton,15
+19,Tampa Bay,13,Sarasota Mall,5
+20,Detroit,19,Roseville,20
+21,Detroit,19,Madison Heights,5
+22,Detroit,19,Middlebelt,20
+23,Detroit,19,Haggerty,10
+24,Detroit,19,Lakeside,5
+25,Detroit,19,Bloomfield,60
+26,Detroit,19,Commerce Township,20
+27,Detroit,19,Auburn Hills,10
+28,Detroit,19,Ann Arbor,20
+29,Detroit,19,Brighton,20
+30,Portland,13,Tigard,20
+31,Portland,13,Clackamas,15
+32,Portland,13,Aloha,15
+33,Portland,13,Portland,5
+34,Portland,13,Vancouver WA,15
+35,Portland,13,E Vancouver WA,10
+36,Portland,13,Hillsboro,5
+37,Portland,13,Wilsonville,15
+38,Minneapolis,12,Minneapolis Business Center,20
+39,Minneapolis,12,St Louis Park,20
+40,Minneapolis,12,Eagan,5
+41,Minneapolis,12,Maple Grove,10
+42,Minneapolis,12,Eden Prairie,5
+43,Minneapolis,12,Maplewood,20
+44,Minneapolis,12,Woodbury,5
+45,Minneapolis,12,Coon Rapids,15
+46,Minneapolis,12,Burnsville,10
+47,Phoenix,18,Phoenix Business Center,10
+48,Phoenix,18,Phoenix (Montebello Ave),20
+49,Phoenix,18,Thomas Road (Arcadia Crossing),20
+50,Phoenix,18,Tempe,30
+51,Phoenix,18,Avondale,30
+52,Phoenix,18,Paradise Valley,15
+53,Phoenix,18,Gilbert (Arizona Ave),30
+54,Phoenix,18,Chandler,15
+55,Phoenix,18,N Phoenix (27th Ave),20
+56,Phoenix,18,Cave Creek,5
+57,Phoenix,18,Scottsdale,15
+58,Phoenix,18,Glendale,15
+59,Phoenix,18,SE Gilbert (Market St),15
+60,Phoenix,18,Mesa,15
+61,Atlanta,10,Brookhaven,5
+62,Atlanta,10,Cumberland Mall,5
+63,Atlanta,10,Perimeter,5
+64,Atlanta,10,Morrow Business Center,5
+65,Atlanta,10,Gwinnett,5
+66,Atlanta,10,Town Center,5
+67,Atlanta,10,Alpharetta,15
+68,Atlanta,10,Woodstock,20
+69,Atlanta,10,Sharpsburg,20
+70,Atlanta,10,Mall Of Georgia,15
+71,Atlanta,10,Cumming,10
+72,Denver,12,Denver Business Center,5
+73,Denver,12,Arvada,20
+74,Denver,12,Sheridan,15
+75,Denver,12,Aurora,10
+76,Denver,12,SW Denver (Quincy Ave),10
+77,Denver,12,Westminster,5
+78,Denver,12,Douglas County (Park Meadows),20
+79,Denver,12,Parker,10
+80,Denver,12,Thornton,15
+81,Denver,12,Superior,15
+82,Denver,12,Timnath,10
+83,Seattle,13,Seattle,1
+84,Seattle,13,Kirkland,1
+85,Seattle,13,Tukwila,10
+86,Seattle,13,Redmond,15
+87,Seattle,13,Aurora Village,20
+88,Seattle,13,Issaquah,1
+89,Seattle,13,Woodinville,20
+90,Seattle,13,Lynnwood Business Center,5
+91,Seattle,13,Lynnwood,20
+92,Seattle,13,Silverdale,5
+93,Seattle,13,Covington,15
+94,Seattle,13,Gig Harbor,15
+95,Seattle,13,Everett,30
+96,Seattle,13,Federal Way,15
+97,Seattle,13,Fife Business Center,5
+98,Seattle,13,Tacoma,20
+99,Seattle,13,Puyallup,15
+100,Seattle,13,Bonney Lake,5
+101,Seattle,13,Marysville,20
+102,Chicago,13,Chicago South Loop,10
+103,Chicago,13,Lincoln Park,15
+104,Chicago,13,North Riverside IL,20
+105,Chicago,13,Bedford Park Business Center,10
+106,Chicago,13,Melrose Park,15
+107,Chicago,13,Niles,15
+108,Chicago,13,Oak Brook,20
+109,Chicago,13,Glenview,1
+110,Chicago,13,Mt Prospect,15
+111,Chicago,13,Orland Park,10
+112,Chicago,13,Bolingbrook,15
+113,Chicago,13,Schaumburg,15
+114,Chicago,13,Bloomingdale,15
+115,Chicago,13,Mettawa,15
+116,Chicago,13,Lake Zurich,10
+117,Chicago,13,Naperville,15
+118,Chicago,13,Merrillville,5
+119,Chicago,13,St Charles,10
+120,Chicago,13,Lake In The Hills,15
+121,Houston,22,Cypress,5
+122,Houston,22,Galleria,120
+123,Houston,22,Bunker Hill,20
+124,Houston,22,Pearland,5
+125,Houston,22,Willowbrook,15
+126,Houston,22,Humble,20
+127,Houston,22,Sugar Land,10
+128,Houston,22,Webster,10
+129,Houston,22,W Katy,5
+130,Houston,22,Woodlands,10
+131,Miami,10,Miami,5
+132,Miami,10,N Miami,10
+133,Miami,10,Miami Lakes,5
+134,Miami,10,Kendall,5
+135,Miami,10,Pembroke Pines,10
+136,Miami,10,Davie,5
+137,Miami,10,Pompano,10
+138,Miami,10,Coral Springs,15
+139,Miami,10,Boca Raton,20
+140,Miami,10,Lantana,20
+141,Miami,10,Royal Palm Beach,10
+142,Miami,10,Palm Beach Gardens,5
+143,New York,14,Brooklyn,10
+144,New York,14,Queens,60
+145,New York,14,Manhattan,15
+146,New York,14,Rego Park,20
+147,New York,14,Staten Island,5
+148,New York,14,Lawrence,10
+149,New York,14,New Rochelle,10
+150,New York,14,Yonkers,15
+151,New York,14,Oceanside,1
+152,New York,14,Westbury,15
+153,New York,14,Port Chester,5
+154,New York,14,Nanuet,15
+155,New York,14,Melville,5
+156,New York,14,Commack,5
+157,New York,14,Nesconset,15
+158,New York,14,Holbrook,10
+159,New York,14,Riverhead,15
+160,Inland Empire,17,Chino Hills,10
+161,Inland Empire,17,Eastvale,15
+162,Inland Empire,17,Fontana,45
+163,Inland Empire,17,Lake Elsinore,15
+164,Inland Empire,17,Lancaster,20
+165,Inland Empire,17,Montclair,20
+166,Inland Empire,17,Moreno Valley,20
+167,Inland Empire,17,Rancho Cucamonga,5
+168,Inland Empire,17,San Bernardino,10
+169,Inland Empire,17,Temecula,15
+170,Inland Empire,17,Victorville,15
+171,Los Angeles,13,Alhambra,5
+172,Los Angeles,13,Azusa,20
+173,Los Angeles,13,Burbank,10
+174,Los Angeles,13,Burbank Business Center,10
+175,Los Angeles,13,City of Industry,15
+176,Los Angeles,13,Commerce Business Center,15
+177,Los Angeles,13,Culver City,30
+178,Los Angeles,13,Hawthorne,15
+179,Los Angeles,13,Hawthorne Business Center,15
+180,Los Angeles,13,Inglewood,5
+181,Los Angeles,13,Lakewood,5
+182,Los Angeles,13,Los Feliz,1
+183,Los Angeles,13,Monterey Park,15
+184,Los Angeles,13,Northridge,5
+185,Los Angeles,13,Norwalk,15
+186,Los Angeles,13,Oxnard,5
+187,Los Angeles,13,Pacoima,30
+188,Los Angeles,13,San Dimas,20
+189,Los Angeles,13,Santa Clarita,10
+190,Los Angeles,13,Signal Hill,20
+191,Los Angeles,13,Simi Valley,5
+192,Los Angeles,13,Torrance,15
+193,Los Angeles,13,Van Nuys,5
+194,Los Angeles,13,Westlake Village,15
+195,Los Angeles,13,Woodland Hills,20
+196,Dallas/Fort Worth,10,Arlington,5
+197,Dallas/Fort Worth,10,Dallas,30
+198,Dallas/Fort Worth,10,Dallas Business Center,10
+199,Dallas/Fort Worth,10,Duncanville,5
+200,Dallas/Fort Worth,10,E Plano,15
+201,Dallas/Fort Worth,10,Fort Worth,5
+202,Dallas/Fort Worth,10,Frisco,10
+203,Dallas/Fort Worth,10,Lewisville,10
+204,Dallas/Fort Worth,10,McKinney,15
+205,Dallas/Fort Worth,10,N Fort Worth,5
+206,Dallas/Fort Worth,10,Rockwall,15
+207,Dallas/Fort Worth,10,Southlake,1
+208,Dallas/Fort Worth,10,W Plano,10
+209,Las Vegas,14,SW Henderson (Saint Rose Pkwy),20
+210,Las Vegas,14,Henderson (Marks St),15
+211,Las Vegas,14,Summerlin,5
+212,Las Vegas,14,Centennial,15
+213,Las Vegas,14,Las Vegas Business Center,15
+214,San Diego,16,Carlsbad,20
+215,San Diego,16,Carmel Mountain,10
+216,San Diego,16,Chula Vista,5
+217,San Diego,16,El Centro,15
+218,San Diego,16,La Mesa,30
+219,San Diego,16,La Quinta,10
+220,San Diego,16,Mission Valley,20
+221,San Diego,16,Morena,30
+222,San Diego,16,Palm Desert,20
+223,San Diego,16,Poway,5
+224,San Diego,16,Rancho Del Rey,20
+225,San Diego,16,San Diego Business Center,10
+226,San Diego,16,San Marcos,30
+227,San Diego,16,Santee,20
+228,San Diego,16,SE San Diego,10
+229,San Diego,16,Vista,1

--- a/3. Costco/costco_financial_information.py
+++ b/3. Costco/costco_financial_information.py
@@ -1,0 +1,83 @@
+import pandas as pd
+import yfinance as yf
+
+from datetime import datetime
+from plotly.subplots import make_subplots
+
+def get_yf_data(ticker_list, start_date, end_date):
+    """
+    Connects to the yfinance API and pulls stock information data based
+    on input parameter conditions.
+    
+    :param [String] ticker_list: String list containing stock ticker 
+        codes for companies.
+    :param datetime start_date: Start date to get stock performance 
+        range.
+    :param datetime end_date: End date to get stock performance range.
+    :return pd.DataFrame: Dataframe containing valuation data for the 
+        supplied stock codes within the supplied date range.
+    """
+
+    df_list = []
+
+    # Loop through ticker list and call yfinance API to pull stock data 
+    for ticker in ticker_list:
+        ticker_df = yf.download(ticker, start=start_date, end=end_date)
+        df_list.append(ticker_df)
+
+    # Concat all stock information in one dataframe
+    stock_perf_df = pd.concat(df_list, keys=ticker_list, names=["Ticker", "Date"])
+    stock_perf_df = stock_perf_df.reset_index()
+
+    print(stock_perf_df.head())
+
+    return stock_perf_df
+
+
+def calc_price_change(stock_perf_df):
+    """
+    Calculates some simple performance metrics for stocks.
+    1. Percent change
+    2. 20 Day Moving Average
+    3. 100 Day Moving Average
+
+    :param pd.DataFrame stock_perf_df: Dataframe containing stock 
+        data over a defined time frame.
+    :return Pandas Dataframe: Modified stock performance df with new
+        columns added.
+    """
+    stock_perf_df["Adj Previous Close"] = stock_perf_df["Adj Close"].shift(1)
+    stock_perf_df["Adj Pct Change"] = stock_perf_df[["Open","Adj Previous Close"]].pct_change(axis=1)["Adj Previous Close"]
+    
+    stock_perf_df["Previous Close"] = stock_perf_df["Close"].shift(1)
+    stock_perf_df["Pct Change"] = stock_perf_df[["Open","Previous Close"]].pct_change(axis=1)["Previous Close"]
+    
+    stock_perf_df['20 Day MA'] = stock_perf_df.groupby('Ticker')['Adj Close'].rolling(window=20).mean().reset_index(0, drop=True)
+    stock_perf_df['100 Day MA'] = stock_perf_df.groupby('Ticker')['Adj Close'].rolling(window=100).mean().reset_index(0, drop=True)  
+    
+    stock_perf_df = stock_perf_df.drop(axis=1, columns=["Adj Previous Close", "Previous Close", "High", "Low"])
+    
+    return stock_perf_df
+    
+def main():
+    """
+    Driver function for code. you can modify 
+    """
+    print("Running stock prediction model...")
+
+    # Parameters below >>>
+    
+    start_date = datetime.now() - pd.DateOffset(months=12)
+    end_date = datetime.now()
+
+    # Costco, Walmart, Kroger
+    ticker_list = ["COST", "WMT", "KR"]
+    
+    # >>> End parameters
+    stock_perf_df = get_yf_data(ticker_list, start_date, end_date)
+        
+    stock_perf_df = calc_price_change(stock_perf_df)
+    
+    print(stock_perf_df)
+    
+main()

--- a/3. Costco/costco_web_scraper.py
+++ b/3. Costco/costco_web_scraper.py
@@ -1,0 +1,160 @@
+import re
+import requests
+
+import pandas as pd
+
+from bs4 import BeautifulSoup
+from datetime import datetime
+
+def get_web_data(url):
+    """_summary_
+
+    :param _type_ url: _description_
+    :return _type_: _description_
+    """
+    
+    # Making a GET request
+    try:
+        r = requests.get(url)
+        
+        # check status code for response received
+        if r.status_code == 200:
+            print(f"...Success pulling data from {url}")
+            
+    except:
+        print("Error in pulling")
+        return None
+        # print(e)
+
+    # Parsing the HTML 
+    soup = BeautifulSoup(r.content, "html.parser")
+    return soup
+
+def get_city_names():
+    city_url_dict = {}
+    # For right now, won't get the company names dynamically. There
+    # is a radius slider on the website that doesn't allos you to pull
+    # for all available Costcos automatically.
+    # city_name_soup = get_web_data("https://www.isitpacked.com/place-category/costco/")
+    # city_name_list = extract_costco_data(soup, "Get all city names with avialable data")
+    
+    # Single city name + url for testing
+    city_name = "Tampa Bay"
+    url = "https://www.isitpacked.com/place/costco-tampa-bay/"
+    
+    # Dictionary of all available city names from isitpacked.com
+    city_name_list = [
+        "Costco Orange County, CA",
+        "Costco Tampa Bay",
+        "Costco Detroit",
+        "Costco Portland",
+        "Costco Minneapolis-St. Paul",
+        "Costco Phoenix",
+        "Costco Atlanta",
+        "Costco Denver",
+        "Costco Seattle-Tacoma",
+        "Costco Chicago",
+        "Costco Houston",
+        "Costco Miami",
+        "Costco New York",
+        "Costco Inland Empire",
+        "Costco Los Angeles",
+        "Costco Dallas/Fort Worth",
+        "Costco Las Vegas",
+        "Costco San Diego"
+    ]
+    
+    for city_name in city_name_list:
+        city = city_name.replace("Costco ", "")
+        
+        url_city = re.sub('[^A-Za-z0-9]+', '-', city_name.lower())
+        url = f"https://www.isitpacked.com/place/{url_city}/"
+        
+        city_url_dict[city] = url
+        
+    return city_url_dict
+
+def extract_costco_data(soup):
+    # Parse through soup object to get the required live data
+    city_name_soup = soup.find("div", class_="rpt_plan").find("div", class_="rpt_recurrence")
+    city_name = city_name_soup.find("strong").get_text()
+
+    city_avg_wait = soup.find("div", class_="rpt_price").get_text()
+
+    location_avg_wait = soup.find("table")
+    
+    city_locations_dict = {}
+
+    # Convert html table of average wait per location to Python dict
+    for row in location_avg_wait.find_all("tr"):
+        col = row.find_all("td")
+        if len(col) > 0:
+            try:
+                key = col[0].contents[0]
+                value = col[1].contents[0]
+                
+                city_locations_dict[key] = value
+            
+            except IndexError:
+                if len(col[0].contents) > 0 or len(col[1].contents) > 0:
+                    print("IndexError: Couldn't pull any values for this row")
+                    print(col)
+                # Else, the col variable was empty 
+                # col[0].contents or col[1].contents delivered an empty list []
+
+    # print("City Name:")
+    # print(city_name)
+    # print("City Average Wait:") 
+    # print(city_avg_wait)
+    # print("Average wait for locations within city:")
+    # print(city_locations_dict)
+    
+    return {"city_name": city_name,
+            "city_avg_wait": city_avg_wait,
+            "city_locations_info": city_locations_dict}
+    
+def costco_data_cleanup(costco_wait_times_list):
+    temp_costco_df = pd.DataFrame.from_dict(costco_wait_times_list)
+    
+    # We need to explode out the dictionary in the city_locations_info 
+    # column to be able to use the more specific locatino data.
+    store_location_df = pd.DataFrame([*temp_costco_df['city_locations_info']],temp_costco_df.index).stack().\
+        rename_axis([None,'store_location']).reset_index(1, name='location_wait')
+        
+    costco_cleaned_df = temp_costco_df[['city_name', 'city_avg_wait']].join(store_location_df).reset_index(drop=True)
+    
+    for col_name in ['city_avg_wait', 'location_wait']:
+        costco_cleaned_df[col_name] = costco_cleaned_df[col_name].str.replace("min", "").astype(int)
+    
+    return costco_cleaned_df
+
+def main():
+    current_time = datetime.now().isoformat(' ', 'minutes')
+    costco_wait_times_list = []
+    
+    city_url_dict = get_city_names()
+    
+    for city_name, url in city_url_dict.items():
+        print(f"Pulling Costco wait time data for   {city_name}   as of {current_time}...")
+    
+        soup = get_web_data(url)
+    
+        if soup:
+            costco_city_info_dict = extract_costco_data(soup)
+            # print(costco_city_info_dict)
+            
+            costco_wait_times_list.append(costco_city_info_dict)
+        else:
+            print("There was an error pulling website data. Nothing to parse.")
+    
+    #data cleanup and convert to pandas df [:-3]
+    print("Finished pulling all city data.")
+    print(len(costco_wait_times_list))
+    
+    costco_cleaned_df = costco_data_cleanup(costco_wait_times_list)
+    print(costco_cleaned_df.dtypes)
+    
+    current_time_csv_tag = re.sub('[^A-Za-z0-9]+', '_', current_time)
+    costco_cleaned_df.to_csv(f"Costco_Wait_Times_US_{current_time_csv_tag}.csv")
+    
+main()

--- a/3. Costco/costco_web_scraper.py
+++ b/3. Costco/costco_web_scraper.py
@@ -74,7 +74,7 @@ def get_city_names():
     ]
     
     # Format the city name for readability and create url for each city
-    for city_name in city_name_list[0:4]:
+    for city_name in city_name_list:
         city = city_name.replace("Costco ", "")
         
         url_city = re.sub('[^A-Za-z0-9]+', '-', city_name.lower())
@@ -191,6 +191,6 @@ def main():
     
     # Save to csv
     current_time_csv_tag = re.sub('[^A-Za-z0-9]+', '_', current_time)
-    # costco_cleaned_df.to_csv(f"Costco_Wait_Times_US_{current_time_csv_tag}.csv")
+    costco_cleaned_df.to_csv(f"Costco_Wait_Times_US_{current_time_csv_tag}.csv")
     
 main()

--- a/3. Costco/data/Costco_Wait_Times_US_2024_06_19_13_29.csv
+++ b/3. Costco/data/Costco_Wait_Times_US_2024_06_19_13_29.csv
@@ -1,0 +1,231 @@
+,city_name,city_avg_wait,store_location,location_wait
+0,"Orange County, CA",10,Cypress,10
+1,"Orange County, CA",10,Fountain Valley,1
+2,"Orange County, CA",10,Fullerton,5
+3,"Orange County, CA",10,Garden Grove,15
+4,"Orange County, CA",10,Huntington Beach,10
+5,"Orange County, CA",10,Irvine,10
+6,"Orange County, CA",10,La Habra,10
+7,"Orange County, CA",10,Laguna Marketplace,20
+8,"Orange County, CA",10,Laguna Niguel,10
+9,"Orange County, CA",10,San Juan Capistrano,10
+10,"Orange County, CA",10,Tustin,5
+11,"Orange County, CA",10,Tustin Ranch,15
+12,"Orange County, CA",10,Westminster Business Center,10
+13,"Orange County, CA",10,Yorba Linda,5
+14,Tampa Bay,13,Brandon,15
+15,Tampa Bay,13,W Tampa (Linebaugh Ave),10
+16,Tampa Bay,13,Clearwater,20
+17,Tampa Bay,13,Wesley Chapel,15
+18,Tampa Bay,13,Bradenton,15
+19,Tampa Bay,13,Sarasota Mall,5
+20,Detroit,19,Roseville,20
+21,Detroit,19,Madison Heights,5
+22,Detroit,19,Middlebelt,20
+23,Detroit,19,Haggerty,10
+24,Detroit,19,Lakeside,5
+25,Detroit,19,Bloomfield,60
+26,Detroit,19,Commerce Township,20
+27,Detroit,19,Auburn Hills,10
+28,Detroit,19,Ann Arbor,20
+29,Detroit,19,Brighton,20
+30,Portland,13,Tigard,20
+31,Portland,13,Clackamas,15
+32,Portland,13,Aloha,15
+33,Portland,13,Portland,5
+34,Portland,13,Vancouver WA,15
+35,Portland,13,E Vancouver WA,10
+36,Portland,13,Hillsboro,5
+37,Portland,13,Wilsonville,15
+38,Minneapolis,12,Minneapolis Business Center,20
+39,Minneapolis,12,St Louis Park,20
+40,Minneapolis,12,Eagan,5
+41,Minneapolis,12,Maple Grove,10
+42,Minneapolis,12,Eden Prairie,5
+43,Minneapolis,12,Maplewood,20
+44,Minneapolis,12,Woodbury,5
+45,Minneapolis,12,Coon Rapids,15
+46,Minneapolis,12,Burnsville,10
+47,Phoenix,18,Phoenix Business Center,10
+48,Phoenix,18,Phoenix (Montebello Ave),20
+49,Phoenix,18,Thomas Road (Arcadia Crossing),20
+50,Phoenix,18,Tempe,30
+51,Phoenix,18,Avondale,30
+52,Phoenix,18,Paradise Valley,15
+53,Phoenix,18,Gilbert (Arizona Ave),30
+54,Phoenix,18,Chandler,15
+55,Phoenix,18,N Phoenix (27th Ave),20
+56,Phoenix,18,Cave Creek,5
+57,Phoenix,18,Scottsdale,15
+58,Phoenix,18,Glendale,15
+59,Phoenix,18,SE Gilbert (Market St),15
+60,Phoenix,18,Mesa,15
+61,Atlanta,10,Brookhaven,5
+62,Atlanta,10,Cumberland Mall,5
+63,Atlanta,10,Perimeter,5
+64,Atlanta,10,Morrow Business Center,5
+65,Atlanta,10,Gwinnett,5
+66,Atlanta,10,Town Center,5
+67,Atlanta,10,Alpharetta,15
+68,Atlanta,10,Woodstock,20
+69,Atlanta,10,Sharpsburg,20
+70,Atlanta,10,Mall Of Georgia,15
+71,Atlanta,10,Cumming,10
+72,Denver,12,Denver Business Center,5
+73,Denver,12,Arvada,20
+74,Denver,12,Sheridan,15
+75,Denver,12,Aurora,10
+76,Denver,12,SW Denver (Quincy Ave),10
+77,Denver,12,Westminster,5
+78,Denver,12,Douglas County (Park Meadows),20
+79,Denver,12,Parker,10
+80,Denver,12,Thornton,15
+81,Denver,12,Superior,15
+82,Denver,12,Timnath,10
+83,Seattle,13,Seattle,1
+84,Seattle,13,Kirkland,1
+85,Seattle,13,Tukwila,10
+86,Seattle,13,Redmond,15
+87,Seattle,13,Aurora Village,20
+88,Seattle,13,Issaquah,1
+89,Seattle,13,Woodinville,20
+90,Seattle,13,Lynnwood Business Center,5
+91,Seattle,13,Lynnwood,20
+92,Seattle,13,Silverdale,5
+93,Seattle,13,Covington,15
+94,Seattle,13,Gig Harbor,15
+95,Seattle,13,Everett,30
+96,Seattle,13,Federal Way,15
+97,Seattle,13,Fife Business Center,5
+98,Seattle,13,Tacoma,20
+99,Seattle,13,Puyallup,15
+100,Seattle,13,Bonney Lake,5
+101,Seattle,13,Marysville,20
+102,Chicago,13,Chicago South Loop,10
+103,Chicago,13,Lincoln Park,15
+104,Chicago,13,North Riverside IL,20
+105,Chicago,13,Bedford Park Business Center,10
+106,Chicago,13,Melrose Park,15
+107,Chicago,13,Niles,15
+108,Chicago,13,Oak Brook,20
+109,Chicago,13,Glenview,1
+110,Chicago,13,Mt Prospect,15
+111,Chicago,13,Orland Park,10
+112,Chicago,13,Bolingbrook,15
+113,Chicago,13,Schaumburg,15
+114,Chicago,13,Bloomingdale,15
+115,Chicago,13,Mettawa,15
+116,Chicago,13,Lake Zurich,10
+117,Chicago,13,Naperville,15
+118,Chicago,13,Merrillville,5
+119,Chicago,13,St Charles,10
+120,Chicago,13,Lake In The Hills,15
+121,Houston,22,Cypress,5
+122,Houston,22,Galleria,120
+123,Houston,22,Bunker Hill,20
+124,Houston,22,Pearland,5
+125,Houston,22,Willowbrook,15
+126,Houston,22,Humble,20
+127,Houston,22,Sugar Land,10
+128,Houston,22,Webster,10
+129,Houston,22,W Katy,5
+130,Houston,22,Woodlands,10
+131,Miami,10,Miami,5
+132,Miami,10,N Miami,10
+133,Miami,10,Miami Lakes,5
+134,Miami,10,Kendall,5
+135,Miami,10,Pembroke Pines,10
+136,Miami,10,Davie,5
+137,Miami,10,Pompano,10
+138,Miami,10,Coral Springs,15
+139,Miami,10,Boca Raton,20
+140,Miami,10,Lantana,20
+141,Miami,10,Royal Palm Beach,10
+142,Miami,10,Palm Beach Gardens,5
+143,New York,14,Brooklyn,10
+144,New York,14,Queens,60
+145,New York,14,Manhattan,15
+146,New York,14,Rego Park,20
+147,New York,14,Staten Island,5
+148,New York,14,Lawrence,10
+149,New York,14,New Rochelle,10
+150,New York,14,Yonkers,15
+151,New York,14,Oceanside,1
+152,New York,14,Westbury,15
+153,New York,14,Port Chester,5
+154,New York,14,Nanuet,15
+155,New York,14,Melville,5
+156,New York,14,Commack,5
+157,New York,14,Nesconset,15
+158,New York,14,Holbrook,10
+159,New York,14,Riverhead,15
+160,Inland Empire,17,Chino Hills,10
+161,Inland Empire,17,Eastvale,15
+162,Inland Empire,17,Fontana,45
+163,Inland Empire,17,Lake Elsinore,15
+164,Inland Empire,17,Lancaster,20
+165,Inland Empire,17,Montclair,20
+166,Inland Empire,17,Moreno Valley,20
+167,Inland Empire,17,Rancho Cucamonga,5
+168,Inland Empire,17,San Bernardino,10
+169,Inland Empire,17,Temecula,15
+170,Inland Empire,17,Victorville,15
+171,Los Angeles,13,Alhambra,5
+172,Los Angeles,13,Azusa,20
+173,Los Angeles,13,Burbank,10
+174,Los Angeles,13,Burbank Business Center,10
+175,Los Angeles,13,City of Industry,15
+176,Los Angeles,13,Commerce Business Center,15
+177,Los Angeles,13,Culver City,30
+178,Los Angeles,13,Hawthorne,15
+179,Los Angeles,13,Hawthorne Business Center,15
+180,Los Angeles,13,Inglewood,5
+181,Los Angeles,13,Lakewood,5
+182,Los Angeles,13,Los Feliz,1
+183,Los Angeles,13,Monterey Park,15
+184,Los Angeles,13,Northridge,5
+185,Los Angeles,13,Norwalk,15
+186,Los Angeles,13,Oxnard,5
+187,Los Angeles,13,Pacoima,30
+188,Los Angeles,13,San Dimas,20
+189,Los Angeles,13,Santa Clarita,10
+190,Los Angeles,13,Signal Hill,20
+191,Los Angeles,13,Simi Valley,5
+192,Los Angeles,13,Torrance,15
+193,Los Angeles,13,Van Nuys,5
+194,Los Angeles,13,Westlake Village,15
+195,Los Angeles,13,Woodland Hills,20
+196,Dallas/Fort Worth,10,Arlington,5
+197,Dallas/Fort Worth,10,Dallas,30
+198,Dallas/Fort Worth,10,Dallas Business Center,10
+199,Dallas/Fort Worth,10,Duncanville,5
+200,Dallas/Fort Worth,10,E Plano,15
+201,Dallas/Fort Worth,10,Fort Worth,5
+202,Dallas/Fort Worth,10,Frisco,10
+203,Dallas/Fort Worth,10,Lewisville,10
+204,Dallas/Fort Worth,10,McKinney,15
+205,Dallas/Fort Worth,10,N Fort Worth,5
+206,Dallas/Fort Worth,10,Rockwall,15
+207,Dallas/Fort Worth,10,Southlake,1
+208,Dallas/Fort Worth,10,W Plano,10
+209,Las Vegas,14,SW Henderson (Saint Rose Pkwy),20
+210,Las Vegas,14,Henderson (Marks St),15
+211,Las Vegas,14,Summerlin,5
+212,Las Vegas,14,Centennial,15
+213,Las Vegas,14,Las Vegas Business Center,15
+214,San Diego,16,Carlsbad,20
+215,San Diego,16,Carmel Mountain,10
+216,San Diego,16,Chula Vista,5
+217,San Diego,16,El Centro,15
+218,San Diego,16,La Mesa,30
+219,San Diego,16,La Quinta,10
+220,San Diego,16,Mission Valley,20
+221,San Diego,16,Morena,30
+222,San Diego,16,Palm Desert,20
+223,San Diego,16,Poway,5
+224,San Diego,16,Rancho Del Rey,20
+225,San Diego,16,San Diego Business Center,10
+226,San Diego,16,San Marcos,30
+227,San Diego,16,Santee,20
+228,San Diego,16,SE San Diego,10
+229,San Diego,16,Vista,1

--- a/3. Costco/data/Costco_Wait_Times_US_2024_06_19_13_35.csv
+++ b/3. Costco/data/Costco_Wait_Times_US_2024_06_19_13_35.csv
@@ -1,0 +1,231 @@
+,city_name,city_avg_wait,store_location,location_wait
+0,"Orange County, CA",14,Cypress,10
+1,"Orange County, CA",14,Fountain Valley,1
+2,"Orange County, CA",14,Fullerton,20
+3,"Orange County, CA",14,Garden Grove,15
+4,"Orange County, CA",14,Huntington Beach,15
+5,"Orange County, CA",14,Irvine,10
+6,"Orange County, CA",14,La Habra,15
+7,"Orange County, CA",14,Laguna Marketplace,30
+8,"Orange County, CA",14,Laguna Niguel,10
+9,"Orange County, CA",14,San Juan Capistrano,15
+10,"Orange County, CA",14,Tustin,5
+11,"Orange County, CA",14,Tustin Ranch,20
+12,"Orange County, CA",14,Westminster Business Center,10
+13,"Orange County, CA",14,Yorba Linda,15
+14,Tampa Bay,16,Brandon,15
+15,Tampa Bay,16,W Tampa (Linebaugh Ave),10
+16,Tampa Bay,16,Clearwater,20
+17,Tampa Bay,16,Wesley Chapel,15
+18,Tampa Bay,16,Bradenton,15
+19,Tampa Bay,16,Sarasota Mall,20
+20,Detroit,21,Roseville,5
+21,Detroit,21,Madison Heights,20
+22,Detroit,21,Middlebelt,20
+23,Detroit,21,Haggerty,15
+24,Detroit,21,Lakeside,20
+25,Detroit,21,Bloomfield,60
+26,Detroit,21,Commerce Township,15
+27,Detroit,21,Auburn Hills,15
+28,Detroit,21,Ann Arbor,20
+29,Detroit,21,Brighton,15
+30,Portland,16,Tigard,20
+31,Portland,16,Clackamas,15
+32,Portland,16,Aloha,15
+33,Portland,16,Portland,5
+34,Portland,16,Vancouver WA,20
+35,Portland,16,E Vancouver WA,15
+36,Portland,16,Hillsboro,15
+37,Portland,16,Wilsonville,20
+38,Minneapolis,12,Minneapolis Business Center,5
+39,Minneapolis,12,St Louis Park,10
+40,Minneapolis,12,Eagan,20
+41,Minneapolis,12,Maple Grove,5
+42,Minneapolis,12,Eden Prairie,20
+43,Minneapolis,12,Maplewood,15
+44,Minneapolis,12,Woodbury,15
+45,Minneapolis,12,Coon Rapids,5
+46,Minneapolis,12,Burnsville,10
+47,Phoenix,17,Phoenix Business Center,10
+48,Phoenix,17,Phoenix (Montebello Ave),15
+49,Phoenix,17,Thomas Road (Arcadia Crossing),20
+50,Phoenix,17,Tempe,5
+51,Phoenix,17,Avondale,30
+52,Phoenix,17,Paradise Valley,20
+53,Phoenix,17,Gilbert (Arizona Ave),30
+54,Phoenix,17,Chandler,20
+55,Phoenix,17,N Phoenix (27th Ave),10
+56,Phoenix,17,Cave Creek,20
+57,Phoenix,17,Scottsdale,20
+58,Phoenix,17,Glendale,15
+59,Phoenix,17,SE Gilbert (Market St),5
+60,Phoenix,17,Mesa,20
+61,Atlanta,13,Brookhaven,10
+62,Atlanta,13,Cumberland Mall,5
+63,Atlanta,13,Perimeter,20
+64,Atlanta,13,Morrow Business Center,5
+65,Atlanta,13,Gwinnett,5
+66,Atlanta,13,Town Center,20
+67,Atlanta,13,Alpharetta,15
+68,Atlanta,13,Woodstock,20
+69,Atlanta,13,Sharpsburg,15
+70,Atlanta,13,Mall Of Georgia,15
+71,Atlanta,13,Cumming,15
+72,Denver,9,Denver Business Center,5
+73,Denver,9,Arvada,5
+74,Denver,9,Sheridan,10
+75,Denver,9,Aurora,10
+76,Denver,9,SW Denver (Quincy Ave),10
+77,Denver,9,Westminster,10
+78,Denver,9,Douglas County (Park Meadows),5
+79,Denver,9,Parker,15
+80,Denver,9,Thornton,10
+81,Denver,9,Superior,15
+82,Denver,9,Timnath,5
+83,Seattle,12,Seattle,1
+84,Seattle,12,Kirkland,1
+85,Seattle,12,Tukwila,30
+86,Seattle,12,Redmond,20
+87,Seattle,12,Aurora Village,15
+88,Seattle,12,Issaquah,1
+89,Seattle,12,Woodinville,15
+90,Seattle,12,Lynnwood Business Center,5
+91,Seattle,12,Lynnwood,15
+92,Seattle,12,Silverdale,20
+93,Seattle,12,Covington,15
+94,Seattle,12,Gig Harbor,5
+95,Seattle,12,Everett,15
+96,Seattle,12,Federal Way,5
+97,Seattle,12,Fife Business Center,5
+98,Seattle,12,Tacoma,15
+99,Seattle,12,Puyallup,5
+100,Seattle,12,Bonney Lake,20
+101,Seattle,12,Marysville,15
+102,Chicago,13,Chicago South Loop,10
+103,Chicago,13,Lincoln Park,15
+104,Chicago,13,North Riverside IL,15
+105,Chicago,13,Bedford Park Business Center,10
+106,Chicago,13,Melrose Park,5
+107,Chicago,13,Niles,15
+108,Chicago,13,Oak Brook,20
+109,Chicago,13,Glenview,1
+110,Chicago,13,Mt Prospect,20
+111,Chicago,13,Orland Park,10
+112,Chicago,13,Bolingbrook,20
+113,Chicago,13,Schaumburg,10
+114,Chicago,13,Bloomingdale,15
+115,Chicago,13,Mettawa,15
+116,Chicago,13,Lake Zurich,20
+117,Chicago,13,Naperville,10
+118,Chicago,13,Merrillville,5
+119,Chicago,13,St Charles,15
+120,Chicago,13,Lake In The Hills,20
+121,Houston,23,Cypress,5
+122,Houston,23,Galleria,120
+123,Houston,23,Bunker Hill,5
+124,Houston,23,Pearland,15
+125,Houston,23,Willowbrook,10
+126,Houston,23,Humble,5
+127,Houston,23,Sugar Land,15
+128,Houston,23,Webster,15
+129,Houston,23,W Katy,15
+130,Houston,23,Woodlands,20
+131,Miami,10,Miami,10
+132,Miami,10,N Miami,15
+133,Miami,10,Miami Lakes,15
+134,Miami,10,Kendall,10
+135,Miami,10,Pembroke Pines,5
+136,Miami,10,Davie,5
+137,Miami,10,Pompano,5
+138,Miami,10,Coral Springs,15
+139,Miami,10,Boca Raton,10
+140,Miami,10,Lantana,5
+141,Miami,10,Royal Palm Beach,10
+142,Miami,10,Palm Beach Gardens,15
+143,New York,15,Brooklyn,10
+144,New York,15,Queens,60
+145,New York,15,Manhattan,15
+146,New York,15,Rego Park,15
+147,New York,15,Staten Island,10
+148,New York,15,Lawrence,20
+149,New York,15,New Rochelle,20
+150,New York,15,Yonkers,15
+151,New York,15,Oceanside,1
+152,New York,15,Westbury,15
+153,New York,15,Port Chester,5
+154,New York,15,Nanuet,15
+155,New York,15,Melville,5
+156,New York,15,Commack,15
+157,New York,15,Nesconset,10
+158,New York,15,Holbrook,10
+159,New York,15,Riverhead,20
+160,Inland Empire,18,Chino Hills,5
+161,Inland Empire,18,Eastvale,15
+162,Inland Empire,18,Fontana,45
+163,Inland Empire,18,Lake Elsinore,20
+164,Inland Empire,18,Lancaster,20
+165,Inland Empire,18,Montclair,15
+166,Inland Empire,18,Moreno Valley,20
+167,Inland Empire,18,Rancho Cucamonga,5
+168,Inland Empire,18,San Bernardino,5
+169,Inland Empire,18,Temecula,30
+170,Inland Empire,18,Victorville,20
+171,Los Angeles,14,Alhambra,5
+172,Los Angeles,14,Azusa,20
+173,Los Angeles,14,Burbank,5
+174,Los Angeles,14,Burbank Business Center,20
+175,Los Angeles,14,City of Industry,15
+176,Los Angeles,14,Commerce Business Center,20
+177,Los Angeles,14,Culver City,30
+178,Los Angeles,14,Hawthorne,15
+179,Los Angeles,14,Hawthorne Business Center,10
+180,Los Angeles,14,Inglewood,10
+181,Los Angeles,14,Lakewood,20
+182,Los Angeles,14,Los Feliz,1
+183,Los Angeles,14,Monterey Park,20
+184,Los Angeles,14,Northridge,5
+185,Los Angeles,14,Norwalk,10
+186,Los Angeles,14,Oxnard,15
+187,Los Angeles,14,Pacoima,30
+188,Los Angeles,14,San Dimas,15
+189,Los Angeles,14,Santa Clarita,10
+190,Los Angeles,14,Signal Hill,5
+191,Los Angeles,14,Simi Valley,10
+192,Los Angeles,14,Torrance,10
+193,Los Angeles,14,Van Nuys,15
+194,Los Angeles,14,Westlake Village,30
+195,Los Angeles,14,Woodland Hills,10
+196,Dallas/Fort Worth,15,Arlington,5
+197,Dallas/Fort Worth,15,Dallas,30
+198,Dallas/Fort Worth,15,Dallas Business Center,10
+199,Dallas/Fort Worth,15,Duncanville,20
+200,Dallas/Fort Worth,15,E Plano,20
+201,Dallas/Fort Worth,15,Fort Worth,20
+202,Dallas/Fort Worth,15,Frisco,20
+203,Dallas/Fort Worth,15,Lewisville,20
+204,Dallas/Fort Worth,15,McKinney,15
+205,Dallas/Fort Worth,15,N Fort Worth,15
+206,Dallas/Fort Worth,15,Rockwall,5
+207,Dallas/Fort Worth,15,Southlake,1
+208,Dallas/Fort Worth,15,W Plano,20
+209,Las Vegas,12,SW Henderson (Saint Rose Pkwy),30
+210,Las Vegas,12,Henderson (Marks St),5
+211,Las Vegas,12,Summerlin,5
+212,Las Vegas,12,Centennial,5
+213,Las Vegas,12,Las Vegas Business Center,15
+214,San Diego,18,Carlsbad,20
+215,San Diego,18,Carmel Mountain,5
+216,San Diego,18,Chula Vista,5
+217,San Diego,18,El Centro,30
+218,San Diego,18,La Mesa,15
+219,San Diego,18,La Quinta,15
+220,San Diego,18,Mission Valley,20
+221,San Diego,18,Morena,30
+222,San Diego,18,Palm Desert,20
+223,San Diego,18,Poway,20
+224,San Diego,18,Rancho Del Rey,15
+225,San Diego,18,San Diego Business Center,10
+226,San Diego,18,San Marcos,30
+227,San Diego,18,Santee,20
+228,San Diego,18,SE San Diego,30
+229,San Diego,18,Vista,1


### PR DESCRIPTION
A few python scripts that mess around with Costco data
1. costco_web_scraper.py - pulls live time data from isitpacked.com to see the wait times for Costcos throughout the US
2. coscto_financial_information.py - uses ideas from the basic stock analysis project to pull stock information for Costco and similar companies through yfinance

Hoping to put this in a dashboard!